### PR TITLE
Version resources with pid/time and pull in SmolStr.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +299,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -518,6 +533,8 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "once_cell",
+ "smol_str",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -1151,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1716,6 +1733,16 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smol_str"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66eaf762c5af19db3108300515c8aa7a50efc90ff745f4c62288052ebf9fdd25"
+dependencies = [
+ "borsh",
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.17", features = ["derive"] }
 crossbeam-skiplist = "0.1"
 enum-map = "2.7"
 futures = "0.3"
@@ -12,6 +13,9 @@ h2 = "0.3"
 http = "0.2"
 k8s-openapi = { version = "0.21", features = ["v1_29"] }
 kube = { version = "0.88", features = ["runtime", "client", "derive"] }
+once_cell = "1.19"
+smol_str = "0.3"
+thiserror = "1.0"
 tokio = { version = "1.38", features = ["full"] }
 tokio-stream = "0.1"
 tonic = "0.11"
@@ -20,6 +24,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tower = "0.4"
 tower-http = { version = "0.4", features = ["metrics", "trace"] }
-once_cell = "1.19"
 xds-api = { version = "0.1", features = ["descriptor"] }
-clap = { version = "4.5.17" , features = ["derive"] }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -3,7 +3,9 @@ mod connection;
 mod resources;
 mod server;
 
-pub(crate) use cache::{new_snapshot, Snapshot, SnapshotWriter, TypedWriters};
+pub(crate) use cache::{
+    new_snapshot, Snapshot, SnapshotWriter, TypedWriters, VersionCounter,
+};
 pub(crate) use connection::AdsConnection;
 pub(crate) use resources::ResourceType;
 pub(crate) use server::AdsServer;

--- a/src/xds/cache.rs
+++ b/src/xds/cache.rs
@@ -1,13 +1,136 @@
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+use std::{
+    num::NonZeroU64,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::SystemTime,
 };
 
 use crossbeam_skiplist::SkipMap;
 use enum_map::EnumMap;
+use once_cell::sync::Lazy;
 use xds_api::pb::google::protobuf;
 
 use crate::xds::resources::ResourceType;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResourceVersion(NonZeroU64);
+
+impl ResourceVersion {
+    const EPOCH_MASK: u64 = (1 << 48) - 1;
+    const PREFIX_MASK: u64 = !Self::EPOCH_MASK;
+
+    /// Create a new ResourceVersion from a u64. Returns `None` if the value is
+    /// zero.
+    pub(crate) fn new(v: u64) -> Option<Self> {
+        NonZeroU64::new(v).map(Self)
+    }
+
+    /// Create a ResourceVersion from an epoch-millis timestamp and an already
+    /// shifted prefix. Panics if the prefix and epoch_ms are both zero.
+    pub(crate) fn from_raw_parts(prefix: u64, epoch_ms: u64) -> Self {
+        let version = prefix | (epoch_ms & Self::EPOCH_MASK);
+        Self(version.try_into().expect("masked a zero ResourceVersion"))
+    }
+
+    fn as_parts(&self) -> (u64, u64) {
+        let v = self.0.get();
+        let prefix = (v & ResourceVersion::PREFIX_MASK) >> 48;
+        let epoch = v & ResourceVersion::EPOCH_MASK;
+        (prefix, epoch)
+    }
+
+    fn to_u64(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl std::fmt::Debug for ResourceVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for ResourceVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (prefix, epoch) = self.as_parts();
+        f.write_fmt(format_args!("{prefix}.{epoch}"))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParseVersionError {
+    #[error("resource version cannot be 0.0")]
+    Zero,
+
+    #[error("failed to parse resource version")]
+    ParseError,
+}
+
+impl FromStr for ResourceVersion {
+    type Err = ParseVersionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (first, second) = s.split_once('.').ok_or(ParseVersionError::ParseError)?;
+        let prefix: u16 = first.parse().map_err(|_| ParseVersionError::ParseError)?;
+        let epoch_ms: u64 = second.parse().map_err(|_| ParseVersionError::ParseError)?;
+
+        if prefix == 0 && epoch_ms == 0 {
+            return Err(ParseVersionError::Zero);
+        }
+
+        // safety: it's safe to skip the mask as prefix was parsed as a u16.
+        let prefix = (prefix as u64) << 48;
+        let epoch_ms = epoch_ms & Self::EPOCH_MASK;
+        Ok(Self::from_raw_parts(prefix, epoch_ms))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct VersionCounter {
+    prefix: u64,
+}
+
+impl VersionCounter {
+    pub(crate) fn new(prefix: u16) -> Self {
+        let prefix = (prefix as u64) << 48;
+        Self { prefix }
+    }
+
+    pub(crate) fn with_process_prefix() -> Self {
+        Self::new(Self::process_preifx())
+    }
+
+    fn process_preifx() -> u16 {
+        static PREFIX: Lazy<u16> = Lazy::new(|| {
+            use std::hash::Hash;
+            use std::hash::Hasher;
+
+            let mut hasher = std::hash::DefaultHasher::new();
+            // pid
+            std::process::id().hash(&mut hasher);
+            // POD_NAME env var
+            std::env::var("POD_NAME")
+                .ok()
+                .inspect(|pod_name| pod_name.hash(&mut hasher));
+
+            hasher.finish() as u16
+        });
+        *PREFIX
+    }
+
+    pub(crate) fn next(&self) -> ResourceVersion {
+        let elapsed = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("your clock is set before January 1, 1970");
+
+        // safety: in the distant future, this cast will truncate and that's
+        // fine. at worst we're wasting a few instructions not masking first.
+        ResourceVersion::from_raw_parts(self.prefix, elapsed.as_millis() as u64)
+    }
+}
 
 pub(crate) type Entry<'a> = crossbeam_skiplist::map::Entry<'a, String, VersionedProto>;
 
@@ -32,7 +155,7 @@ pub(crate) fn new_snapshot() -> (Snapshot, TypedWriters) {
 }
 
 pub(crate) struct VersionedProto {
-    pub version: u64,
+    pub version: ResourceVersion,
     pub proto: protobuf::Any,
 }
 
@@ -57,10 +180,11 @@ struct ResourceSnapshot {
 }
 
 impl Snapshot {
-    pub fn version(&self, resource_type: ResourceType) -> u64 {
-        self.inner.typed[resource_type]
+    pub fn version(&self, resource_type: ResourceType) -> Option<ResourceVersion> {
+        let v = self.inner.typed[resource_type]
             .version
-            .load(Ordering::SeqCst)
+            .load(Ordering::SeqCst);
+        ResourceVersion::new(v)
     }
 
     pub fn get(&self, resource_type: ResourceType, resource_name: &str) -> Option<Entry> {
@@ -82,12 +206,12 @@ impl Snapshot {
 impl SnapshotWriter {
     pub fn update(
         &self,
-        version: u64,
+        version: ResourceVersion,
         resources: impl Iterator<Item = (String, Option<protobuf::Any>)>,
     ) {
         let typed = &self.inner.typed[self.resource_type];
 
-        typed.version.store(version, Ordering::SeqCst);
+        typed.version.store(version.to_u64(), Ordering::SeqCst);
         for (k, v) in resources {
             match v {
                 Some(proto) => {


### PR DESCRIPTION
# Resource Versions

Instead of versioning everything with a monotonic counter, use a resource version based on a 16-bit hash of the current process id (more on that below) and the current unix timestamp as a 48-bit integer. Resource IDs are formatted as `{pid}.{time}` strings when sent over xDS.

In most environments, the current timestamp is monotonic enough to be a reasonable starting place while still keeping ezbake stateless. Given the pace of kube updates and the coalescing we do, milliseconds is fine grained enough. 48 bits of unix time is a little over 8,000 years. If ezbake is still running then, I'm sorry.

The pid identifier is a hash of the current process id and the `POD_NAME` environment variable. The combination of these two things should be unique enough inside and outside kubernetes to avoid having two processes generate the same identifier.

# SmolStr

This PR also pulls in SmolStr to reduce the size of the nonce strings we track for every subscription. SmolStr is a stack-allocatable, cheaply-cloneable String. The crate comes from the rust-analyzer team and is used there.