### PR TITLE
More actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,63 @@
-name: Regression Build and Test
+name: CI
 
-on: 
+on:
   push:
     branches: [ "main" ]
-    
+
   pull_request:
     branches: [ "main" ]
-  
+
 env:
   CARGO_TERM_COLOR: always
+  rust_stable: stable
+  rust_min: 1.76
 
 jobs:
-  test:
+  msrv:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-
-    - name: Build
-      run: cargo build --verbose
-      
-    - name: Run tests
-      run: cargo test --verbose
+    - name: "Install Rust @${{ env.rust_min }}"
+      uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: ${{ env.rust_min }}
+    - uses: Swatinem/rust-cache@v2
+    - name: check
+      run: cargo check
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Install Rust @${{ env.rust_stable }}"
+      uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: ${{ env.rust_stable }}
+    - uses: Swatinem/rust-cache@v2
+    - name: test
+      run: cargo test
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Install Rust @ ${{ env.rust_stable }}"
+      uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: ${{ env.rust_stable }}
+    - uses: Swatinem/rust-cache@v2
+    - name: clippy
+      run: cargo clippy --all --tests --all-features --no-deps
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Install Rust @ ${{ env.rust_stable }}"
+      uses: dtolnay/rust-toolchain@stable
+      with:
+          toolchain: ${{ env.rust_stable }}
+    - uses: Swatinem/rust-cache@v2
+    - name: fmt
+      run: |
+        if ! rustfmt --check --edition 2021 $(git ls-files '*.rs'); then
+          echo "rustfmt found un-formatted files" >&2
+          exit 1
+        fi


### PR DESCRIPTION
Spilt actions into fmt, test, msrv, and clippy. Use the same install-rust and cache actions that [tokio uses](https://github.com/tokio-rs/tokio/blob/32970527633bb72fc4f01d02523484a9376ac26a/.github/workflows/ci.yml).