### PR TITLE
Use junction-api names for xDS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "async-stream"
@@ -134,7 +134,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -357,7 +357,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -453,7 +453,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1080,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "junction-api"
 version = "0.1.0"
-source = "git+https://github.com/junction-labs/junction-client#f555c4e5f2ce726c6cd72fd931f69a6e558030b0"
+source = "git+https://github.com/junction-labs/junction-client?branch=benl/name#7b0691b12a734115df4d7e078c4b15c9ee0e154b"
 dependencies = [
  "gateway-api",
  "http 1.1.0",
@@ -1088,7 +1088,6 @@ dependencies = [
  "kube",
  "once_cell",
  "regex",
- "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -1186,7 +1185,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1477,7 +1476,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1508,7 +1507,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1567,7 +1566,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1814,7 +1813,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1893,7 +1892,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -1904,14 +1903,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -2033,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2075,7 +2074,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2124,7 +2123,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2276,7 +2275,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -2422,7 +2421,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-shared",
 ]
 
@@ -2444,7 +2443,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2608,7 +2607,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.82",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tower = "0.4"
 tower-http = { version = "0.4", features = ["metrics", "trace"] }
 xds-api = { version = "0.1", features = ["descriptor"] }
 
-junction-api = { git = "https://github.com/junction-labs/junction-client", features = [
+junction-api = { git = "https://github.com/junction-labs/junction-client", branch = "benl/name", features = [
     "kube",
     "xds",
 ] }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -302,12 +302,3 @@ async fn sleep_until(deadline: &Option<Instant>) {
         None => futures::future::pending().await,
     }
 }
-
-pub(crate) fn ref_namespace_and_name<T: KubeResource>(
-    obj_ref: &ObjectRef<T>,
-) -> Option<(&str, &str)> {
-    let namespace = obj_ref.namespace.as_ref()?;
-    let name = &obj_ref.name;
-
-    Some((namespace, name))
-}

--- a/src/xds/cache.rs
+++ b/src/xds/cache.rs
@@ -146,11 +146,6 @@ pub(crate) struct Snapshot {
     inner: Arc<SnapshotInner>,
 }
 
-pub(crate) struct SnapshotWriter {
-    resource_type: ResourceType,
-    inner: Arc<SnapshotInner>,
-}
-
 pub(crate) fn new_snapshot() -> (Snapshot, TypedWriters) {
     let inner = Arc::new(SnapshotInner::default());
     (
@@ -198,6 +193,12 @@ impl Snapshot {
         self.inner.typed[resource_type].resources.get(resource_name)
     }
 
+    pub fn contains(&self, resource_type: ResourceType, resource_name: &str) -> bool {
+        self.inner.typed[resource_type]
+            .resources
+            .contains_key(resource_name)
+    }
+
     pub fn len(&self, resource_type: ResourceType) -> usize {
         self.inner.typed[resource_type].resources.len()
     }
@@ -210,7 +211,18 @@ impl Snapshot {
     }
 }
 
+pub(crate) struct SnapshotWriter {
+    resource_type: ResourceType,
+    inner: Arc<SnapshotInner>,
+}
+
 impl SnapshotWriter {
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            inner: self.inner.clone(),
+        }
+    }
+
     pub fn update(
         &self,
         version: ResourceVersion,


### PR DESCRIPTION
Leans even more into the previous commit to use names generated by junction-api for xDS. This means we rely much less on k8s object naming directly in ezbake, which makes caching and deleting resources a bit harder. This commit is - ironically - underbaked, and leaks some xDS resources on Service deletion.

# Branch deps?

The naming scheme change hasn't been merged to `main` on `junction-client` yet (See https://github.com/junction-labs/junction-client/pull/49). As part of the chicken-and-egg dance here, we're going to push a built container with ezbake depending on a branch of `junction-api`, and then move back to `main` once `junction-api` settles down.