### PR TITLE
Rewrite the ezbake ingest loop as a single task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "async-broadcast"
@@ -284,9 +284,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "junction-api"
 version = "0.1.0"
-source = "git+https://github.com/junction-labs/junction-client#cf2108c1687c6f8abc37a990ae4412c156edf2d1"
+source = "git+https://github.com/junction-labs/junction-client#a835efaf2f32031b7326162c773181b31fcdb830"
 dependencies = [
  "gateway-api",
  "http 1.1.0",
@@ -1667,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -2033,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2212,18 +2212,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -119,13 +119,10 @@ impl KubeResource for EndpointSlice {
     }
 
     fn parent_refs(&self) -> Vec<ObjectRef<Self::ParentRef>> {
-        let Some(labels) = self.metadata.labels.as_ref() else {
-            return Vec::new();
-        };
         let Some(svc_namespace) = self.metadata.namespace.as_ref() else {
             return Vec::new();
         };
-        let Some(svc_name) = labels.get("kubernetes.io/service-name") else {
+        let Some(svc_name) = self.labels().get("kubernetes.io/service-name") else {
             return Vec::new();
         };
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -82,6 +82,14 @@ pub(crate) use describe_timer;
 /// Creates a timer that runs until it goes out of scope. Timed values are
 /// tracked with a metrics histogram and assumes that durations are recorded as
 /// an f64 number of seconds.
+///
+/// ```no_run
+/// let _timer = scoped_timer!(
+///   "my-timer", "label_one" => "value", "label_two" => "another-value"
+/// );
+///
+///  // do stuff and the timer runs to the end of the current scope
+/// ```
 macro_rules! scoped_timer {
     ($name:expr $(, $label_key:expr $(=> $label_value:expr)?)* $(,)?) => {{
         let hist = ::metrics::histogram!($name $(, $label_key $(=> $label_value)?)*);

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -3,7 +3,9 @@ mod connection;
 mod resources;
 mod server;
 
-pub(crate) use cache::{new_snapshot, Snapshot, SnapshotWriter, TypedWriters, VersionCounter};
+pub(crate) use cache::{
+    snapshot_cache, ResourceSnapshot, SnapshotCache, SnapshotWriter, VersionCounter,
+};
 pub(crate) use connection::AdsConnection;
 pub(crate) use resources::ResourceType;
 pub(crate) use server::AdsServer;

--- a/src/xds/resources.rs
+++ b/src/xds/resources.rs
@@ -28,6 +28,7 @@ impl ResourceType {
         }
     }
 
+    #[allow(unused)]
     pub(crate) fn all() -> &'static [Self] {
         &[
             Self::Listener,


### PR DESCRIPTION
The first iteration of ezbake assumed a nice, simple mapping of Kube resources to xDS. this stopped being true with the interaction between HTTPRoutes and Services - there are now multiple ways to generate Listeners, and they interact with each other. Making everything serialized means we can index and share state when reacting to HTTPRoute and Service changes, and be a little bit saner. As a bonus, this update now includes tests.

This update lumps EndpointSlice updates in with the rest of the ingest tasks, even though it still appears to be independent. If this becomes a performance bottleneck later, it can move into its own task again.

There are a bunch of other smaller changes here to how we handle updates and errors and things like that, but none of them are really worth calling out - they're just abstractions that were overfit to the original implementation and had to change.