### PR TITLE
Make snapshot updates more consistent

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn main() {
     }
 
     let client = kube::Client::try_default().await.unwrap();
-    let (cache, writer) = xds::snapshot_cache();
+    let (cache, writer) = xds::snapshot();
 
     let ingest = ingest(
         &client,

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -3,9 +3,7 @@ mod connection;
 mod resources;
 mod server;
 
-pub(crate) use cache::{
-    snapshot_cache, ResourceSnapshot, SnapshotCache, SnapshotWriter, VersionCounter,
-};
+pub(crate) use cache::{snapshot, ResourceSnapshot, SnapshotCache, SnapshotWriter, VersionCounter};
 pub(crate) use connection::AdsConnection;
 pub(crate) use resources::ResourceType;
 pub(crate) use server::AdsServer;


### PR DESCRIPTION
Snapshot updates used a debouncing timer I wrote based on the last time a resource type had updated. I'm not sure why I originally picked this approach - maybe less coordination with channels?

It had been acting a bit flaky with demos, so it's now a single broadcast channel. This seems to be much more reliable so far.