### PR TITLE
Update with the new verison of junction-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "junction-api"
 version = "0.1.1"
-source = "git+https://github.com/junction-labs/junction-client#eccb1598ab53743280aaa5d6d7f37808b64e4c60"
+source = "git+https://github.com/junction-labs/junction-client#96ef8bf04fafcbf6ac1b4605720844f6f01afad0"
 dependencies = [
  "gateway-api",
  "http 1.1.0",
@@ -1217,6 +1217,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "smol_str",
  "thiserror",
  "xds-api",
 ]

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -3,7 +3,9 @@ mod connection;
 mod resources;
 mod server;
 
-pub(crate) use cache::{snapshot, ResourceSnapshot, SnapshotCache, SnapshotWriter, VersionCounter};
+pub(crate) use cache::{
+    snapshot, ResourceSnapshot, SnapshotCache, SnapshotCallback, SnapshotWriter,
+};
 pub(crate) use connection::AdsConnection;
 pub(crate) use resources::ResourceType;
 pub(crate) use server::AdsServer;

--- a/src/xds/connection.rs
+++ b/src/xds/connection.rs
@@ -467,7 +467,7 @@ impl<'s> Iterator for SnapshotIter<'_, 's> {
 
 #[cfg(test)]
 mod test {
-    use crate::xds::cache::ResourceVersion;
+
     use crate::xds::{ResourceSnapshot, SnapshotWriter};
 
     use super::*;
@@ -1090,7 +1090,7 @@ mod test {
             "some-endpoints".to_string(),
             anything(),
         );
-        writer.update(ResourceVersion::from_parts(0xBEEF, 124), snapshot);
+        writer.update(snapshot);
 
         // when the client ACKs the first response, it shouldn't change the state of the connection
         let (_, resp) = conn
@@ -1134,9 +1134,8 @@ mod test {
             }
         }
 
-        let version = ResourceVersion::from_parts(0xBEEF, max_version);
-        let (cache, mut writer) = crate::xds::snapshot();
-        writer.update(version, snapshot);
+        let (cache, mut writer) = crate::xds::snapshot([]);
+        writer.update(snapshot);
 
         (cache, writer)
     }


### PR DESCRIPTION
Swaps to using hostnames and ports for route matching with the new version of junction-api (junction-labs/junction-client#96). The new Client lookup flow is roughly:

- A client makes a request for an xDS Listener named `hostname:port`.
- The server looks to see if it has a cached Listener for that `hostname:port`, if so it's returned immediately.
- On a cache miss, ezbake walks it's index to find a match for that `(hostname, port)` pair, respecting wildcards. If one exists, it creates an RDS Listener pointing to that Route and returns it.

### The Index and Implicit Routes

Ingesting kube resources now updates an index that maps hostnames and ports to Route names. It is an extremely poor index - we do a linear walk on every lookup that is not in cache. For ezbake this is fine - this is intended to be a demo server with ~tens of routes, and the generated listener is cached. There are plenty of other "it's a demo" problems we have here too - nothing is checking that there are no conflicting routes, etc - but hey, it's a demo.

One of the things the index does correctly is that it's a two-level index: explicitly created Routes match before routes generated by ezbake.

### ExternalName Services and ParentRefs

One of the weird things that's come up more and more is that it's hard to convert Kube objects 1:1 with Junction objects without building context. This really got highlighted this time with ExternalName Services, which need to be referenced in Gateway HTTPRoute as kubernetes Services, but we want to reference in Junction Routes as DNS Services. This is a pretty annoying fundamental mismatch, and means that the way to create a Route for a DNS name is:

```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httpbin-external
  namespace: default
spec:
  parentRefs:
  - name: httpbin.org
    kind: DNS
    group: "junctionlabs.io"
  rules:
  - backendRefs:
    - name: "httpbin.org"
      namespace: default
      group: "junctionlabs.io"
      kind: "DNS"
      port: 80
---
apiVersion: v1
kind: Service
metadata:
  name: httpbin-external
spec:
  type: ExternalName
  externalName: "httpbin.org"
```

This absolutely violates all expectations of any Kubernetes user - the referenced object should be the `httpbin-external` Service, but here you have to understand Junction well enough to know that the HTTPRoute references a Junction DNS route and that a Junction DNS Route is getting magically created for the `httpbin-external` Service.

After some IRL discussion, we're going to land this for now anyway, but we don't want to keep this behavior around for any longer than we have to. It's gross.