### PR TITLE
Fix an A-B-A Listener update race

### DIFF
--- a/src/xds/connection.rs
+++ b/src/xds/connection.rs
@@ -254,6 +254,7 @@ impl AdsConnection {
         trace!(
             sub_last_sent_version = ?sub.last_sent_version,
             snapshot_version = ?self.snapshot.version(changed_type),
+            ?changed_type,
             "snapshot updated",
         );
         if sub.last_sent_version == self.snapshot.version(changed_type) {


### PR DESCRIPTION
there appears to be an A-B-A style race in the xDS SotW protocol. if a Listener L1@v1 points to a RouteConfig R1@v1, switches to pointing at R2@v2, then points back at R1@v1 the client is - by the spec - supposed to have deleted its cache entry for R1@v1. without tracking the state of the client in detail, the server has no way to know that the client has deleted R1, so it never re-sends R1 back to the client.

to work around this, any time we switch the target of a Listener to an existing Route, we bump the version of the Route to avoid the problem.