### PR TITLE
convert resource versions to ksuids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-encode"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17bd29f7c70f32e9387f4d4acfa5ea7b7749ef784fb78cf382df97069337b8c"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,10 +407,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -479,6 +526,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -598,6 +654,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossbeam",
  "crossbeam-skiplist",
  "enum-map",
  "futures",
@@ -610,6 +667,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "once_cell",
  "smol_str",
+ "svix-ksuid",
  "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
@@ -1483,6 +1541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1718,12 @@ name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2183,6 +2253,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "svix-ksuid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f014385b7fc154f59e9480770c2187b6e61037c2439895788a9a4d421d7859"
+dependencies = [
+ "base-encode",
+ "byteorder",
+ "getrandom",
+ "time",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2340,25 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ junction-api = { git = "https://github.com/junction-labs/junction-client", featu
     "kube",
     "xds",
 ] }
+crossbeam = "0.8.4"
+svix-ksuid = "0.8.0"

--- a/src/xds/cache.rs
+++ b/src/xds/cache.rs
@@ -1,17 +1,13 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    num::NonZeroU64,
     str::FromStr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::SystemTime,
+    sync::Arc,
 };
 
+use crossbeam::atomic::AtomicCell;
 use crossbeam_skiplist::SkipMap;
 use enum_map::EnumMap;
-use once_cell::sync::Lazy;
+use svix_ksuid::{Ksuid, KsuidLike};
 use tokio::sync::broadcast::{self, error::RecvError};
 use tracing::warn;
 use xds_api::pb::google::protobuf;
@@ -106,38 +102,22 @@ impl ResourceSnapshot {
     }
 }
 
-// FIXME: allow more than one version per ms, since even with the debounce we're
-// updating more than once per ms. the time mask should probably change to find
-// a few more bits.
+// NOTE: this uses a ksuid for now. no idea if that's good or not long term, but
+// it's an easy way to get something relatively unique and roughly ordered.
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ResourceVersion(NonZeroU64);
+pub(crate) struct ResourceVersion(Ksuid);
 
 impl ResourceVersion {
-    const EPOCH_MASK: u64 = (1 << 48) - 1;
-    const PREFIX_MASK: u64 = !Self::EPOCH_MASK;
-
     /// Create a new ResourceVersion from a u64. Returns `None` if the value is
     /// zero.
-    pub(crate) fn new(v: u64) -> Option<Self> {
-        NonZeroU64::new(v).map(Self)
+    pub(crate) fn new() -> Self {
+        Self(Ksuid::new(None, None))
     }
+}
 
-    /// Create a ResourceVersion from an epoch-millis timestamp and an already
-    /// shifted prefix. Panics if the prefix and epoch_ms are both zero.
-    pub(crate) fn from_raw_parts(prefix: u64, epoch_ms: u64) -> Self {
-        let version = prefix | (epoch_ms & Self::EPOCH_MASK);
-        Self(version.try_into().expect("masked a zero ResourceVersion"))
-    }
-
-    fn as_parts(&self) -> (u64, u64) {
-        let v = self.0.get();
-        let prefix = (v & ResourceVersion::PREFIX_MASK) >> 48;
-        let epoch = v & ResourceVersion::EPOCH_MASK;
-        (prefix, epoch)
-    }
-
-    fn to_u64(self) -> u64 {
-        self.0.get()
+impl Default for ResourceVersion {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -149,16 +129,12 @@ impl std::fmt::Debug for ResourceVersion {
 
 impl std::fmt::Display for ResourceVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (prefix, epoch) = self.as_parts();
-        f.write_fmt(format_args!("{prefix}.{epoch}"))
+        f.write_fmt(format_args!("{id}", id = self.0))
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ParseVersionError {
-    #[error("resource version cannot be 0.0")]
-    Zero,
-
     #[error("failed to parse resource version")]
     ParseError,
 }
@@ -167,62 +143,22 @@ impl FromStr for ResourceVersion {
     type Err = ParseVersionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (first, second) = s.split_once('.').ok_or(ParseVersionError::ParseError)?;
-        let prefix: u16 = first.parse().map_err(|_| ParseVersionError::ParseError)?;
-        let epoch_ms: u64 = second.parse().map_err(|_| ParseVersionError::ParseError)?;
-
-        if prefix == 0 && epoch_ms == 0 {
-            return Err(ParseVersionError::Zero);
-        }
-
-        // safety: it's safe to skip the mask as prefix was parsed as a u16.
-        let prefix = (prefix as u64) << 48;
-        let epoch_ms = epoch_ms & Self::EPOCH_MASK;
-        Ok(Self::from_raw_parts(prefix, epoch_ms))
+        Ksuid::from_str(s)
+            .map(Self)
+            .map_err(|_| ParseVersionError::ParseError)
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct VersionCounter {
-    prefix: u64,
-}
+pub(crate) struct VersionCounter;
 
 impl VersionCounter {
-    pub(crate) fn new(prefix: u16) -> Self {
-        let prefix = (prefix as u64) << 48;
-        Self { prefix }
-    }
-
-    pub(crate) fn with_process_prefix() -> Self {
-        Self::new(Self::process_preifx())
-    }
-
-    fn process_preifx() -> u16 {
-        static PREFIX: Lazy<u16> = Lazy::new(|| {
-            use std::hash::Hash;
-            use std::hash::Hasher;
-
-            let mut hasher = std::hash::DefaultHasher::new();
-            // pid
-            std::process::id().hash(&mut hasher);
-            // POD_NAME env var
-            std::env::var("POD_NAME")
-                .ok()
-                .inspect(|pod_name| pod_name.hash(&mut hasher));
-
-            hasher.finish() as u16
-        });
-        *PREFIX
+    pub(crate) fn new() -> Self {
+        Self
     }
 
     pub(crate) fn next(&self) -> ResourceVersion {
-        let elapsed = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("your clock is set before January 1, 1970");
-
-        // safety: in the distant future, this cast will truncate and that's
-        // fine. at worst we're wasting a few instructions not masking first.
-        ResourceVersion::from_raw_parts(self.prefix, elapsed.as_millis() as u64)
+        ResourceVersion::new()
     }
 }
 
@@ -260,7 +196,7 @@ pub(crate) fn snapshot(
     }
 
     let inner = Arc::new(SnapshotCacheInner {
-        version: VersionCounter::with_process_prefix(),
+        version: VersionCounter::new(),
         typed: Default::default(),
         callbacks,
         // 12 = 3 cache updates for each of 4 types of resource type.
@@ -296,16 +232,13 @@ struct SnapshotCacheInner {
 
 #[derive(Default)]
 struct ResourceCache {
-    version: AtomicU64,
+    version: AtomicCell<ResourceVersion>,
     resources: SkipMap<String, VersionedProto>,
 }
 
 impl SnapshotCache {
-    pub fn version(&self, resource_type: ResourceType) -> Option<ResourceVersion> {
-        let v = self.inner.typed[resource_type]
-            .version
-            .load(Ordering::SeqCst);
-        ResourceVersion::new(v)
+    pub fn version(&self, resource_type: ResourceType) -> ResourceVersion {
+        self.inner.typed[resource_type].version.load()
     }
 
     pub fn get(&self, resource_type: ResourceType, resource_name: &str) -> Option<Entry> {
@@ -410,7 +343,7 @@ impl SnapshotWriter {
                 // update the cache version AFTER updating all individual resource
                 // versions so that once you can see the snapshot version change,
                 // changes to all resources are visible as well.
-                cache.version.store(version.to_u64(), Ordering::SeqCst);
+                cache.version.store(version);
                 notify[resource_type] = true;
             }
         }

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -51,10 +51,7 @@ impl AdsServer {
 
         grpc_access::xds_discovery_request(&request);
 
-        let Some(snapshot_version) = self.cache.version(resource_type) else {
-            return Err(Status::unavailable("no snapshot available"));
-        };
-
+        let snapshot_version = self.cache.version(resource_type);
         let request_version = request.version_info.parse().ok();
         if request_version == Some(snapshot_version) {
             // TODO: delay/long-poll here? this is what go-control-plane does, but it's odd


### PR DESCRIPTION
Drop our hacky custom resource version counters for [ksuids](https://github.com/segmentio/ksuid). These are unique enough for ezbake, and we won't have collision problems if Kube updates too often.