### PR TITLE
handle incremental xds not-found correctly

### DIFF
--- a/src/xds/resources.rs
+++ b/src/xds/resources.rs
@@ -28,6 +28,10 @@ impl ResourceType {
         }
     }
 
+    pub(crate) const fn supports_wildcard(&self) -> bool {
+        matches!(self, ResourceType::Cluster | ResourceType::Listener)
+    }
+
     /// Return a slice of all resource types, ordered according to Envoy's preferred
     /// make-before-break ordering.
     ///


### PR DESCRIPTION
@inowland pointed out very quickly that #72 didn't actually return not-found responses correctly to the client. This PR fixes that, and correctly handles wildcard removes which we weren't doing either.

### Not-found

On getting a request for a resource that doesn't exist, the server should immediately return a response with that resource name in `remove_resources`. Notably, this doesn't affect whether or not the server tracks that the client is subscribed to the resource - any future snapshot updates that create the resource should immediately send it back to the client.

To make that happen, we now have to track both the set of subscribed resources, and their last sent versions. It was easy to just jam them into separate sets, but I can imagine a scheme where we merge this into a single map. We'll have to play with it.

### Wildcard Removes

When a client sends a remove request for a resource, the server generally should not have to respond. However, if the current subscription is a wildcard subscription, the client may have dropped a resource that's part of the wildcard. To deal with this the server is required to immediately resend the complete resource if it's part of the wildcard, or to immediately send a remove for that resource name if it's not to effectively ACK the removal. This is chatty - it generates a full extra round trip - but is the only way to remove the ambiguity.

Since we're not actually doing wildcard support yet, we always send the extra remove.